### PR TITLE
0.2.0 fix replacement key

### DIFF
--- a/src/app/factom-identity-manager.js
+++ b/src/app/factom-identity-manager.js
@@ -101,7 +101,13 @@ class FactomIdentityManager {
      * @returns {{ txId: string, repeatedCommit: boolean, chainId: string, entryHash: string }} - Info about the Entry insertion.
      */
     async replaceIdentityKey(identityChainId, keys, ecAddress) {
-        return replaceIdentityKey(this.cli, identityChainId, keys, ecAddress);
+        return replaceIdentityKey(
+            this.cli,
+            this.identityRetriever,
+            identityChainId,
+            keys,
+            ecAddress
+        );
     }
 }
 

--- a/src/app/identity-management.js
+++ b/src/app/identity-management.js
@@ -38,7 +38,7 @@ function getIdentityKeys(identityKeys) {
     return result;
 }
 
-async function replaceIdentityKey(cli, identityChainId, keys, ecAddress) {
+async function replaceIdentityKey(cli, identityRetriever, identityChainId, keys, ecAddress) {
     if (!isValidSecretIdentityKey(keys.signingSecretIdKey)) {
         throw new Error('signingSecretIdKey must be a valid secret identity key');
     }
@@ -50,7 +50,7 @@ async function replaceIdentityKey(cli, identityChainId, keys, ecAddress) {
         secret: keys.signingSecretIdKey
     };
 
-    const activeKeys = await getActiveKeysAtHeight(cli, identityChainId);
+    const activeKeys = await identityRetriever.getActiveKeysAtHeight(cli, identityChainId);
 
     if (!activeKeys.includes(oldPublicIdKey)) {
         throw new Error(
@@ -59,12 +59,16 @@ async function replaceIdentityKey(cli, identityChainId, keys, ecAddress) {
     }
     if (!activeKeys.includes(signingIdKey.public)) {
         throw new Error(
-            `Signer identity key ${signingIdKey.public} is not part of the active keys: [${activeKeys}].`
+            `Signer identity key ${
+                signingIdKey.public
+            } is not part of the active keys: [${activeKeys}].`
         );
     }
     if (activeKeys.indexOf(oldPublicIdKey) < activeKeys.indexOf(signingIdKey.public)) {
         throw new Error(
-            `Priority of the signing key ${signingIdKey.public} is not sufficient to replace the key ${oldPublicIdKey}`
+            `Priority of the signing key ${
+                signingIdKey.public
+            } is not sufficient to replace the key ${oldPublicIdKey}`
         );
     }
 

--- a/src/app/identity-management.js
+++ b/src/app/identity-management.js
@@ -5,7 +5,6 @@ const { generateIdentityChain, generateIdentityKeyReplacementEntry } = require('
         getPublicIdentityKey,
         generateRandomIdentityKeyPair
     } = require('./key-helpers');
-const { getActiveKeysAtHeight } = require('./identity-information-retriever');
 
 async function createIdentity(cli, name, keys, ecAddress) {
     const identityKeys = getIdentityKeys(keys);
@@ -50,7 +49,7 @@ async function replaceIdentityKey(cli, identityRetriever, identityChainId, keys,
         secret: keys.signingSecretIdKey
     };
 
-    const activeKeys = await identityRetriever.getActiveKeysAtHeight(cli, identityChainId);
+    const activeKeys = await identityRetriever.getActiveKeysAtHeight(identityChainId);
 
     if (!activeKeys.includes(oldPublicIdKey)) {
         throw new Error(


### PR DESCRIPTION
Right, it was due to wrong copy paste between the project I'm working on and this fork.

You say that `cli` is not used any more within `replaceIdentityKey` but this one makes a final call using it: `return cli.add(entry, ecAddress); `

May you valid this PR and merge it if it is ASAP?

Thank you!